### PR TITLE
If useLocal is true actually use local filesystem

### DIFF
--- a/embed/embed.go
+++ b/embed/embed.go
@@ -255,11 +255,7 @@ type _escFile struct {
 }
 
 func (_escLocalFS) Open(name string) (http.File, error) {
-	f, present := _escData[path.Clean(name)]
-	if !present {
-		return nil, os.ErrNotExist
-	}
-	return os.Open(f.local)
+	return os.Open(path.Clean(name[1:]))
 }
 
 func (_escStaticFS) prepare(name string) (*_escFile, error) {


### PR DESCRIPTION
In some cases it is desirable to add files to the local fs and test without a need to rebuild an executable.  Previously _ascLocalFS.Open() implementation needed the path to exist in the generated map of files in the fs or would fail.  This change removes the dependency for the path to already exist in static FS generation.

Eventually It would be nice to change FS to take a string argument that would direct which filesystem path to use instead of defaulting to to predefined local path.  so after deployment of binary an argument could be provided to allow user to specify a path to use for content.